### PR TITLE
RbacRbacPermission: fix the bug that can't find a prefix table

### DIFF
--- a/src/Rbac/RbacPermission.php
+++ b/src/Rbac/RbacPermission.php
@@ -24,6 +24,6 @@ class RbacPermission extends Model implements RbacPermissionInterface
     public function __construct(array $attributes = [])
     {
         parent::__construct($attributes);
-        $this->table = config('rbac.permissions_table');
+        $this->table = config('entrust.permissions_table');
     }
 }


### PR DESCRIPTION
fix the bug that can't find a prefix table